### PR TITLE
add support for album name scrobbling, custom_song_export, Now Playing, configurable scrobble threshold, improved logging

### DIFF
--- a/src/main/java/main/CHScrobbler.java
+++ b/src/main/java/main/CHScrobbler.java
@@ -64,6 +64,29 @@ public class CHScrobbler
             else
                 dataFolder = prop.getProperty(Statics.DATA_FOLDER_PROP_NAME);
 
+            //validate scrobble threshold seconds
+            int scrobbleThresholdSeconds = 25;
+            String scrobbleThresholdSecondsString = prop.getProperty("scrobble_threshold_seconds");
+
+            if (scrobbleThresholdSecondsString != null && !scrobbleThresholdSecondsString.isEmpty())
+            {
+                try
+                {
+                    scrobbleThresholdSeconds = Integer.parseInt(scrobbleThresholdSecondsString);
+                }
+                catch(NumberFormatException e)
+                {
+                    scrobbleThresholdSeconds = -1;
+                }
+
+                if (scrobbleThresholdSeconds < 1 || scrobbleThresholdSeconds > 240)
+                {
+                    scrobbleThresholdSeconds = 25;
+                    JOptionPane.showMessageDialog(null,"scrobble_threshold_seconds must be a valid number between 1 and 240 seconds (4 minutes).",
+                            Statics.LAST_FM_INIT_ERROR, JOptionPane.ERROR_MESSAGE);
+                }
+            }
+
             //set last.fm api to show only warnings
             Caller.getInstance().getLogger().setLevel(Level.WARNING);
 
@@ -91,7 +114,7 @@ public class CHScrobbler
             else
             {
                 logger.info("Successfully logged in with last.fm!");
-                ScrobblerManager.init(session, dataFolder);
+                ScrobblerManager.init(session, dataFolder, scrobbleThresholdSeconds);
             }
         }
 
@@ -121,7 +144,8 @@ public class CHScrobbler
             System.out.println("You're currently on an old version of CHScrobbler. Please update CHScrobbler using the link above as soon as possible.\n\n");
     }
 
-    private static void initSetup(File file) {
+    private static void initSetup(File file)
+    {
         try
         {
             Setup.init(file);
@@ -129,9 +153,9 @@ public class CHScrobbler
 
         catch(IOException e)
         {
-            e.printStackTrace();
             JOptionPane.showMessageDialog(null,"There was an error making the config file. Please let the dev know.",
                 "Error!", JOptionPane.ERROR_MESSAGE);
+            e.printStackTrace();
         }
     }
 }

--- a/src/main/java/main/CHScrobbler.java
+++ b/src/main/java/main/CHScrobbler.java
@@ -65,7 +65,7 @@ public class CHScrobbler
                 dataFolder = prop.getProperty(Statics.DATA_FOLDER_PROP_NAME);
 
             //validate scrobble threshold seconds
-            int scrobbleThresholdSeconds = 25;
+            int scrobbleThresholdSeconds = Statics.DEFAULT_SCROBBLE_THRESHOLD;
             String scrobbleThresholdSecondsString = prop.getProperty("scrobble_threshold_seconds");
 
             if (scrobbleThresholdSecondsString != null && !scrobbleThresholdSecondsString.isEmpty())
@@ -79,10 +79,10 @@ public class CHScrobbler
                     scrobbleThresholdSeconds = -1;
                 }
 
-                if (scrobbleThresholdSeconds < 1 || scrobbleThresholdSeconds > 240)
+                if (scrobbleThresholdSeconds < Statics.DEFAULT_SCROBBLE_THRESHOLD || scrobbleThresholdSeconds > 240)
                 {
-                    scrobbleThresholdSeconds = 25;
-                    JOptionPane.showMessageDialog(null,"scrobble_threshold_seconds must be a valid number between 1 and 240 seconds (4 minutes).",
+                    scrobbleThresholdSeconds = Statics.DEFAULT_SCROBBLE_THRESHOLD;
+                    JOptionPane.showMessageDialog(null,"scrobble_threshold_seconds must be a valid number between " + Statics.DEFAULT_SCROBBLE_THRESHOLD + " and 240 seconds (4 minutes).",
                             Statics.LAST_FM_INIT_ERROR, JOptionPane.ERROR_MESSAGE);
                 }
             }

--- a/src/main/java/main/ScrobblerManager.java
+++ b/src/main/java/main/ScrobblerManager.java
@@ -180,8 +180,12 @@ public class ScrobblerManager
                     || !scrobbleData.getAlbum().equalsIgnoreCase(album))
             {
                 scrobbleData = new ScrobbleData(artist, track, (int) (System.currentTimeMillis() / 1000));
-                scrobbleData.setAlbum(album);
-                scrobbleData.setAlbumArtist(album);
+
+                if(!album.isEmpty())
+                {
+                    scrobbleData.setAlbum(album);
+                    scrobbleData.setAlbumArtist(artist);
+                }
 
                 Track.updateNowPlaying(scrobbleData, session);
 

--- a/src/main/java/main/ScrobblerManager.java
+++ b/src/main/java/main/ScrobblerManager.java
@@ -2,106 +2,203 @@ package main;
 
 import de.umass.lastfm.Session;
 import de.umass.lastfm.Track;
+import de.umass.lastfm.scrobble.ScrobbleData;
 import de.umass.lastfm.scrobble.ScrobbleResult;
+import methods.EscapeRegex;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 public class ScrobblerManager
 {
     private static String dataDir;
     private static Session session;
-    private static boolean playing = false;
-    private static boolean attemptedScrobble = false;
-    private static boolean warnedNotFound = false;
-    private static String trackArtist = "";
-    private static String trackTitle = "";
-    private static int timestamp;
+    private static ScrobbleData scrobbleData;
+    private static boolean attemptedScrobble;
+    private static boolean warnedNotFound;
+    private static Pattern customSongPattern;
+    private static boolean customSongPatternContainsAlbum;
 
     public static void init(Session session, String dataDir)
     {
         ScrobblerManager.session = session;
         ScrobblerManager.dataDir = dataDir;
+        ScrobblerManager.initCustomSongPattern();
         Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(ScrobblerManager::scrobble, 0, 1, TimeUnit.SECONDS);
+    }
+
+    private static void initCustomSongPattern()
+    {
+        Optional<String> customSongExportSetting = getCustomSongExportSetting();
+        boolean containsTrackAndArtist = customSongExportSetting.map(x -> x.contains("%s") && x.contains("%a")).orElse(true);
+        boolean containsAlbum = customSongExportSetting.map(x -> x.contains("%b")).orElse(false);
+
+        if(!containsTrackAndArtist)
+        {
+            CHScrobbler.getLogger().error("The Clone Hero setting 'custom_song_export' must contain '%s' and '%a'.");
+        }
+
+        if(!containsAlbum)
+        {
+            CHScrobbler.getLogger().warn("The Clone Hero setting 'custom_song_export' should contain '%b'. " +
+                    "This enables CHScrobbler to include the album name when scrobbling.");
+        }
+
+        //no need for regex if custom_song_export is unchanged
+        if(customSongExportSetting.map(x -> x.startsWith("%s%n%a") && !containsAlbum).orElse(true))
+            return;
+
+        String regex = EscapeRegex.escapeRegex(customSongExportSetting.get())
+                .replace("%n", "\\R")
+                .replaceAll("%(\\w)", "(?<$1>.*)");
+
+        ScrobblerManager.customSongPattern = Pattern.compile(regex);
+        ScrobblerManager.customSongPatternContainsAlbum = containsAlbum;
+    }
+
+    private static Optional<String> getCustomSongExportSetting()
+    {
+        Path settingsFilePath = Paths.get(dataDir, "settings.ini");
+
+        if(!Files.exists(settingsFilePath))
+            return Optional.empty();
+
+        try(Stream<String> lines = Files.lines(settingsFilePath, StandardCharsets.UTF_8))
+        {
+            String settingPrefix = "custom_song_export =";
+
+            return lines
+                    .map(String::trim)
+                    .filter(x -> x.startsWith(settingPrefix))
+                    .findFirst()
+                    .map(x -> x.substring(settingPrefix.length()).trim());
+        }
+        catch(IOException e)
+        {
+            CHScrobbler.getLogger().error("Couldn't read the 'settings.ini' file.");
+
+            return Optional.empty();
+        }
     }
 
     private static void scrobble()
     {
+        Path currentSongFilePath = Paths.get(dataDir, "currentsong.txt");
+
+        if(!Files.exists(currentSongFilePath))
+        {
+            if(!warnedNotFound)
+            {
+                System.out.println("Unable to find 'currentsong.txt'! Please make sure you have \"Export Current Song\" " +
+                        "enabled in Settings and your Clone Hero data folder is set correctly.");
+                warnedNotFound = true;
+            }
+
+            return;
+        }
+
+        byte[] currentSongBytes;
+
         try
         {
-            File file = new File(dataDir + "/currentsong.txt");
-            if(!file.exists())
-            {
-                if(!warnedNotFound)
-                {
-                    System.out.println("Unable to find 'currentsong.txt'! Please make sure you have \"Export Current Song\" " +
-                        "enabled in Settings and your Clone Hero data folder is set correctly.");
-                    warnedNotFound = true;
-                }
-            }
-
-            else
-            {
-                List<String> trackInfo = Files.readAllLines(Paths.get(dataDir + "/currentsong.txt"));
-                if(!trackInfo.isEmpty())
-                {
-                    //removes the song speed modifier from the title
-                    String correctedTitle = trackInfo.get(0).replaceAll("(\\(\\d+%\\))", "").trim();
-
-                    if(!trackArtist.equalsIgnoreCase(trackInfo.get(1)) && !trackTitle.equalsIgnoreCase(correctedTitle))
-                    {
-                        timestamp = (int) (System.currentTimeMillis() / 1000);
-                        trackArtist = trackInfo.get(1);
-                        trackTitle = correctedTitle;
-
-                        if(!playing)
-                        {
-                            CHScrobbler.getLogger().info("Now Playing: {} - {}", trackInfo.get(1), correctedTitle);
-                            playing = true;
-                        }
-                    }
-
-                    else
-                    {
-                        if(!attemptedScrobble && (System.currentTimeMillis()/1000 - timestamp >= 25))
-                        {
-                            ScrobbleResult result = Track.scrobble(trackArtist, correctedTitle, timestamp, session);
-
-                            if(result.isSuccessful() && !result.isIgnored())
-                                CHScrobbler.getLogger().info("Scrobbled the currently playing song!");
-                            else
-                                CHScrobbler.getLogger().warn("Couldn't scrobble the currently playing song!");
-
-                            attemptedScrobble = true;
-                        }
-                    }
-                }
-
-                else
-                {
-                    if(playing)
-                    {
-                        playing = false;
-                        attemptedScrobble = false;
-                        trackArtist = "";
-                        trackTitle = "";
-                        timestamp = 0;
-
-                        CHScrobbler.getLogger().info("Currently not playing anything!\r");
-                    }
-                }
-            }
+            currentSongBytes = Files.readAllBytes(currentSongFilePath);
         }
 
         catch(IOException e)
         {
             CHScrobbler.getLogger().error("Sorry, couldn't find or read the 'currentsong.txt' file! Please try opening this app again.");
             Executors.newSingleThreadScheduledExecutor().schedule(() -> System.exit(0), 5, TimeUnit.SECONDS);
+
+            return;
         }
+
+        if(currentSongBytes.length == 0)
+        {
+            clearScrobbleData();
+            return;
+        }
+
+        String currentSong = new String(currentSongBytes, StandardCharsets.UTF_8);
+        if(currentSong.isEmpty())
+        {
+            clearScrobbleData();
+            return;
+        }
+
+        String artist, track, album;
+
+        if(customSongPattern != null)
+        {
+            Matcher matcher = customSongPattern.matcher(currentSong);
+            if(!matcher.find())
+            {
+                clearScrobbleData();
+                return;
+            }
+
+            artist = matcher.group("a").trim();
+            track = matcher.group("s").trim();
+            album = customSongPatternContainsAlbum ? matcher.group("b").trim() : "";
+        }
+
+        else
+        {
+            String[] lines = currentSong.split("\\R");
+
+            artist = lines[1];
+            track = lines[0];
+            album = "";
+        }
+
+        //removes the song speed modifier from the title
+        track = track.replaceAll("(\\(\\d+%\\))", "").trim();
+
+        if(scrobbleData == null
+                || !scrobbleData.getArtist().equalsIgnoreCase(artist)
+                || !scrobbleData.getTrack().equalsIgnoreCase(track)
+                || !scrobbleData.getAlbum().equalsIgnoreCase(album))
+        {
+            scrobbleData = new ScrobbleData(artist, track, (int) (System.currentTimeMillis() / 1000));
+            scrobbleData.setAlbum(album);
+            scrobbleData.setAlbumArtist(album);
+
+            Track.updateNowPlaying(scrobbleData, session);
+
+            CHScrobbler.getLogger().info("Now Playing: {} - {}{}", artist, track, album.isEmpty() ? "" : " - " + album);
+
+            attemptedScrobble = false;
+        }
+
+        else if(!attemptedScrobble && (System.currentTimeMillis() / 1000) - scrobbleData.getTimestamp() >= 25)
+        {
+            ScrobbleResult result = Track.scrobble(scrobbleData, session);
+
+            if(result.isSuccessful() && !result.isIgnored())
+                CHScrobbler.getLogger().info("Scrobbled the currently playing song!");
+            else
+                CHScrobbler.getLogger().warn("Couldn't scrobble the currently playing song!");
+
+            attemptedScrobble = true;
+        }
+    }
+
+    private static void clearScrobbleData()
+    {
+        if(scrobbleData == null)
+            return;
+
+        scrobbleData = null;
+        attemptedScrobble = false;
+
+        CHScrobbler.getLogger().info("Currently not playing anything!");
     }
 }

--- a/src/main/java/methods/EscapeRegex.java
+++ b/src/main/java/methods/EscapeRegex.java
@@ -1,0 +1,13 @@
+package methods;
+
+import java.util.regex.Pattern;
+
+public class EscapeRegex
+{
+    private static final Pattern SPECIAL_REGEX_CHARS = Pattern.compile("[{}()\\[\\].+*?^$\\\\|]");
+
+    public static String escapeRegex(String input)
+    {
+        return SPECIAL_REGEX_CHARS.matcher(input).replaceAll("\\\\$0");
+    }
+}

--- a/src/main/java/methods/ReadURL.java
+++ b/src/main/java/methods/ReadURL.java
@@ -32,6 +32,7 @@ public class ReadURL
         catch(IOException e)
         {
             System.out.println("Unable to check for new updates!");
+            e.printStackTrace();
         }
 
         //if it fails

--- a/src/main/java/methods/Setup.java
+++ b/src/main/java/methods/Setup.java
@@ -66,8 +66,8 @@ public class Setup
                     "lastfm_username=%s\n" +
                     "lastfm_password=%s\n" +
                     "clonehero_data_folder=%s\n" +
-                    "scrobble_threshold_seconds=%s25",
-                    apiKey, secret, user, pass, dataFolder));
+                    "scrobble_threshold_seconds=%s",
+                    apiKey, secret, user, pass, dataFolder, Statics.DEFAULT_SCROBBLE_THRESHOLD));
         }
 
         System.out.println("Excellent! All your details are saved in the 'config.txt' file, so you can change that if you've made a mistake.\n" +

--- a/src/main/java/methods/Setup.java
+++ b/src/main/java/methods/Setup.java
@@ -61,12 +61,13 @@ public class Setup
         try(FileWriter fw = new FileWriter(file))
         {
             fw.write(String.format(
-                "lastfm_apikey=%s\n" +
+                    "lastfm_apikey=%s\n" +
                     "lastfm_secret=%s\n" +
                     "lastfm_username=%s\n" +
                     "lastfm_password=%s\n" +
-                    "clonehero_data_folder=%s",
-                apiKey, secret, user, pass, dataFolder));
+                    "clonehero_data_folder=%s\n" +
+                    "scrobble_threshold_seconds=%s25",
+                    apiKey, secret, user, pass, dataFolder));
         }
 
         System.out.println("Excellent! All your details are saved in the 'config.txt' file, so you can change that if you've made a mistake.\n" +

--- a/src/main/java/methods/Statics.java
+++ b/src/main/java/methods/Statics.java
@@ -4,4 +4,5 @@ public class Statics
 {
     public static final String LAST_FM_INIT_ERROR = "last.fm init error!";
     public static final String DATA_FOLDER_PROP_NAME = "clonehero_data_folder";
+    public static final int DEFAULT_SCROBBLE_THRESHOLD = 30;
 }


### PR DESCRIPTION
Currently, CHScrobbler assumes that the first line of currentsong.txt is always the song title, and the second line is always the artist name. However, Clone Hero has a setting (`custom_song_export`) that allows you to change the format of currentsong.txt. This PR adds functionality to CHScrobbler so it uses the value of `custom_song_export` to ensure it always parses currentsong.txt correctly.

In addition to the above, this PR also enables CHScrobbler to include the album name when scrobbling a track. This only works if you add `%b` to your `custom_song_export` pattern. It does not matter where you put `%b` in the export pattern. If you don't do this, CHScrobbler will still work just fine, it will scrobble without album names like it always has.

I also added support for Last.fm Now Playing. As soon as you begin playing a track, it calls the Last.fm API method `track.updateNowPlaying`. There is no API method to reset Now Playing, this is handled automatically by Last.fm.

Lastly, I made the scrobble threshold configurable. The default is still 25 seconds.

Some thoughts about the code:
- I opted not to add a dependency to a library that can parse .ini files, instead it just reads the lines of settings.ini until it finds "custom_song_export =".
- I made it so that it logs an error if `%s` (track) or `%a` (artist) is missing in `custom_song_export`, but it won't stop the program from running, even though it will run into trouble when it starts reading from currentsong.txt.
- Instead of giving a warning, perhaps the CHScrobbler setup could automatically add `%b` to the `custom_song_export` setting? I'm assuming everyone would want the album name to be included in the scrobble data.
- For performance, I wrote it so that it will only use regex to parse currentsong.txt when it has to. It won't use regex if `custom_song_export` is unchanged.